### PR TITLE
Default value of strokeDashArray

### DIFF
--- a/src/SVG/Line.php
+++ b/src/SVG/Line.php
@@ -11,7 +11,7 @@ readonly class Line implements Stringable
         private float $y1 = 0,
         private float $x2 = 100,
         private float $y2 = 100,
-        private string $strokeDashArray = '',
+        private string $strokeDashArray = 'none',
         private string $stroke = 'black',
         private float $strokeWidth = 1,
         private ?string $transform = null


### PR DESCRIPTION
The `stroke-dasharray` attribute must be set to 'none' if it is not defined.

https://developer.mozilla.org/fr/docs/Web/SVG/Attribute/stroke-dasharray