### PR TITLE
Add support for string labels in the Line chart

### DIFF
--- a/src/Chart.php
+++ b/src/Chart.php
@@ -97,8 +97,12 @@ class Chart
         return $svg;
     }
 
-    public function xFor(float $x): float
+    public function xFor(float|string $x): float
     {
+        if (is_string($x)) {
+            $x = (int) array_search($x, $this->xAxis->data, true);
+        }
+
         $minValue = $this->xAxis->minValue();
         $maxValue = $this->xAxis->maxValue();
         $range = $maxValue - $minValue;

--- a/src/Line/Line.php
+++ b/src/Line/Line.php
@@ -10,7 +10,7 @@ use Maantje\Charts\SVG\Path;
 class Line implements Renderable
 {
     /**
-     * @param  (Point|array{float, float})[]  $points
+     * @param  (Point|array{float|string, float})[]  $points
      */
     public function __construct(
         public array $points = [],
@@ -188,7 +188,7 @@ class Line implements Renderable
     }
 
     /**
-     * @return float[]
+     * @return array<float|string>
      */
     public function xPoints(): array
     {
@@ -201,11 +201,6 @@ class Line implements Renderable
     public function yPoints(): array
     {
         return array_map(fn (Point|array $point) => is_array($point) ? $point[1] : $point->y, $this->points);
-    }
-
-    public function maxXValue(): float
-    {
-        return max($this->xPoints());
     }
 
     public function maxYValue(): float

--- a/tests/Unit/LineChartTest.php
+++ b/tests/Unit/LineChartTest.php
@@ -4,6 +4,7 @@ use Maantje\Charts\Chart;
 use Maantje\Charts\Line\Line;
 use Maantje\Charts\Line\Lines;
 use Maantje\Charts\Line\Point;
+use Maantje\Charts\XAxis;
 
 it('renders line chart', function () {
     $chart = new Chart(
@@ -90,4 +91,54 @@ it('renders empty line chart', function () {
 SVG;
 
     expect(pretty($chart->render()))->toBe($svg);
+});
+
+it('renders line chart with string labels', function () {
+    $chart = new Chart(
+        xAxis: new XAxis(
+            data: ['2025-01', '2025-02', '2025-03', '2025-04'],
+        ),
+        series: [
+            new Lines(
+                lines: [
+                    new Line(
+                        points: [
+                            ['2025-01', 0],
+                            ['2025-02', 4],
+                            ['2025-03', 12],
+                            ['2025-04', 8],
+                        ],
+                    )
+                ]
+            ),
+        ],
+    );
+
+    expect(pretty($chart->render()))->toBe(<<<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600">
+  <rect x="0" y="0" width="800" height="600" fill="white" fill-opacity="1" stroke="none" stroke-width="0" rx="0" ry="0"/>
+  <text x="45" y="555" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="end" dominant-baseline="alphabetic" alignment-baseline="auto">0</text>
+  <text x="45" y="450" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="end" dominant-baseline="alphabetic" alignment-baseline="auto">2</text>
+  <text x="45" y="345" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="end" dominant-baseline="alphabetic" alignment-baseline="auto">5</text>
+  <text x="45" y="240" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="end" dominant-baseline="alphabetic" alignment-baseline="auto">7</text>
+  <text x="45" y="135" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="end" dominant-baseline="alphabetic" alignment-baseline="auto">10</text>
+  <text x="45" y="30" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="end" dominant-baseline="alphabetic" alignment-baseline="auto">12</text>
+  <line x1="55" y1="550" x2="770" y2="550" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="1.000000"/>
+  <text x="55" y="575" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="middle" dominant-baseline="alphabetic" alignment-baseline="auto">2025-01</text>
+  <line x1="55" y1="550" x2="55" y2="545" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="1.000000"/>
+  <text x="293.33333333333" y="575" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="middle" dominant-baseline="alphabetic" alignment-baseline="auto">2025-02</text>
+  <line x1="293.33333333333" y1="550" x2="293.33333333333" y2="545" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="1.000000"/>
+  <text x="531.66666666667" y="575" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="middle" dominant-baseline="alphabetic" alignment-baseline="auto">2025-03</text>
+  <line x1="531.66666666667" y1="550" x2="531.66666666667" y2="545" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="1.000000"/>
+  <text x="770" y="575" font-family="arial" font-size="14" fill="black" stroke="none" stroke-width="0" text-anchor="middle" dominant-baseline="alphabetic" alignment-baseline="auto">2025-04</text>
+  <line x1="770" y1="550" x2="770" y2="545" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="1.000000"/>
+  <line x1="55" y1="445" x2="770" y2="445" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="0.200000"/>
+  <line x1="55" y1="340" x2="770" y2="340" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="0.200000"/>
+  <line x1="55" y1="235" x2="770" y2="235" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="0.200000"/>
+  <line x1="55" y1="130" x2="770" y2="130" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="0.200000"/>
+  <line x1="55" y1="25" x2="770" y2="25" stroke="black" stroke-dasharray="none" stroke-width="1" stroke-opacity="0.200000"/>
+  <path d="M 55,550 L 293.33333333333,375 L 531.66666666667,25 L 770,200" fill="none" stroke="black" stroke-width="5"/>
+</svg>
+SVG
+    );
 });


### PR DESCRIPTION
This PR adds support for textual labels in the Line chart.

Example:
![image](https://github.com/user-attachments/assets/6d432d20-49a8-4b7c-8cd3-23e37a1c380a)
