### PR TITLE
Fix: Remove dash from PieChart labels when label is empty

### DIFF
--- a/src/Pie/PieChart.php
+++ b/src/Pie/PieChart.php
@@ -21,7 +21,8 @@ class PieChart
         public string $color = 'black',
         ?Closure $formatter = null
     ) {
-        $this->formatter = $formatter ?? fn (string $label, float $percentage) => "$label - $percentage%";
+        $this->formatter = $formatter ?? fn (string $label, float $percentage) => 
+            empty(trim($label)) ? "$percentage%" : "$label - $percentage%";
     }
 
     public function render(): string

--- a/src/Pie/PieChart.php
+++ b/src/Pie/PieChart.php
@@ -21,8 +21,7 @@ class PieChart
         public string $color = 'black',
         ?Closure $formatter = null
     ) {
-        $this->formatter = $formatter ?? fn (string $label, float $percentage) => 
-            empty(trim($label)) ? "$percentage%" : "$label - $percentage%";
+        $this->formatter = $formatter ?? fn (string $label, float $percentage) => empty(trim($label)) ? "$percentage%" : "$label - $percentage%";
     }
 
     public function render(): string

--- a/tests/Unit/PieChartEmptyLabelTest.php
+++ b/tests/Unit/PieChartEmptyLabelTest.php
@@ -16,7 +16,7 @@ it('renders pie chart with empty label without dash', function () {
     );
 
     $rendered = $chart->render();
-    
+
     expect($rendered)->toContain('100%');
     expect($rendered)->not->toContain('- 100%');
 });
@@ -34,7 +34,7 @@ it('renders pie chart with whitespace-only label without dash', function () {
     );
 
     $rendered = $chart->render();
-    
+
     expect($rendered)->toContain('100%');
     expect($rendered)->not->toContain('- 100%');
 });
@@ -52,6 +52,6 @@ it('renders pie chart with label including dash', function () {
     );
 
     $rendered = $chart->render();
-    
+
     expect($rendered)->toContain('Test - 100%');
 });

--- a/tests/Unit/PieChartEmptyLabelTest.php
+++ b/tests/Unit/PieChartEmptyLabelTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Maantje\Charts\Pie\PieChart;
+use Maantje\Charts\Pie\Slice;
+
+it('renders pie chart with empty label without dash', function () {
+    $chart = new PieChart(
+        size: 500,
+        slices: [
+            new Slice(
+                value: 100,
+                color: '#5B9BD5',
+                label: '',
+            ),
+        ],
+    );
+
+    $rendered = $chart->render();
+    
+    expect($rendered)->toContain('100%');
+    expect($rendered)->not->toContain('- 100%');
+});
+
+it('renders pie chart with whitespace-only label without dash', function () {
+    $chart = new PieChart(
+        size: 500,
+        slices: [
+            new Slice(
+                value: 100,
+                color: '#5B9BD5',
+                label: '   ',
+            ),
+        ],
+    );
+
+    $rendered = $chart->render();
+    
+    expect($rendered)->toContain('100%');
+    expect($rendered)->not->toContain('- 100%');
+});
+
+it('renders pie chart with label including dash', function () {
+    $chart = new PieChart(
+        size: 500,
+        slices: [
+            new Slice(
+                value: 100,
+                color: '#5B9BD5',
+                label: 'Test',
+            ),
+        ],
+    );
+
+    $rendered = $chart->render();
+    
+    expect($rendered)->toContain('Test - 100%');
+});


### PR DESCRIPTION
## 🐛 **Fix: Remove dash from PieChart labels when label is empty**

### **📝 Description**
Fixes an issue where PieChart slices with empty labels displayed `"- 100%"` instead of just `"100%"`. This change improves the visual appearance by removing the unnecessary dash when no label is provided.

### **🎯 Problem**
- When creating a `Slice` with an empty `label` (`''` or whitespace only), the default formatter displayed `"- 100%"`
- This created visual inconsistency and poor UX in pie charts with mixed labeled/unlabeled slices

### **✅ Solution**
- Modified the default formatter in `PieChart` to check for empty/whitespace-only labels
- **Empty label**: Shows `"100%"` instead of `"- 100%"`
- **Valid label**: Maintains existing format `"Label - 100%"`
- **Whitespace-only label**: Treated as empty and shows `"100%"`

### **🧪 Testing**
- Added comprehensive test suite in PieChartEmptyLabelTest.php
- Tests cover empty labels, whitespace-only labels, and normal labels
- All new tests pass ✅
- Maintains full backward compatibility

### **📋 Changes**
- PieChart.php: Updated default formatter logic
- PieChartEmptyLabelTest.php: Added comprehensive tests

### **🔧 Example**
**Before:**
```php
new Slice(value: 100, color: '#5B9BD5', label: '')  // → "- 100%"
```

**After:**
```php
new Slice(value: 100, color: '#5B9BD5', label: '')  // → "100%"
```
